### PR TITLE
fixing active link based on path

### DIFF
--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -55,6 +55,7 @@ const PageLayout = (props: IProps) => {
             defaultSelectedKeys={['1']}
             mode="inline"
             items={items}
+            selectedKeys={[window.location.pathname]}
           />
           <UserIcon />
         </Sider>


### PR DESCRIPTION
the problem is that when we first navigate to a page using the URL, we see that the associated menu button is not clicked... 
like this 
![before](https://github.com/ManolyaTam/time-wise-ui/assets/83909842/6c14dc74-24a8-43e5-be3c-c50923522132)
now that I fix it, the bottom of the current page is always reading the URL and being "clicked" according to it
![after](https://github.com/ManolyaTam/time-wise-ui/assets/83909842/c53dba31-61f1-40d0-aed4-81d5636f8569)
